### PR TITLE
Cloudfront support

### DIFF
--- a/modules/services/api-gateway.tf
+++ b/modules/services/api-gateway.tf
@@ -19,6 +19,15 @@ resource "aws_api_gateway_stage" "api" {
   stage_name    = "api"
 }
 
+resource "aws_api_gateway_method_settings" "all" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  stage_name  = aws_api_gateway_stage.api.stage_name
+  method_path = "*/*"
+  settings {
+    metrics_enabled = true
+  }
+}
+
 resource "aws_lambda_permission" "api_gateway" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"

--- a/modules/services/api-gateway.tf
+++ b/modules/services/api-gateway.tf
@@ -10,7 +10,12 @@ resource "aws_api_gateway_rest_api" "api" {
 
 resource "aws_api_gateway_deployment" "api" {
   rest_api_id = aws_api_gateway_rest_api.api.id
-  depends_on  = [aws_api_gateway_rest_api.api]
+  triggers = {
+    redeployment = sha256(aws_api_gateway_rest_api.api.body)
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_api_gateway_stage" "api" {

--- a/modules/services/cloudfront.tf
+++ b/modules/services/cloudfront.tf
@@ -1,0 +1,85 @@
+locals {
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-policy-caching-disabled
+  cloudfront_CachingDisabled = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
+  cloudfront_AllViewerExceptHostHeader = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+}
+resource "aws_cloudfront_distribution" "dataplane" {
+  comment      = "Braintrust Dataplane - ${var.deployment_name}"
+  enabled      = true
+  http_version = "http2and3"
+  # Deploy only in North America and Europe. Reduces costs and deployment time.
+  price_class = "PriceClass_100"
+  aliases     = var.custom_domain != null ? [var.custom_domain] : null
+
+  origin {
+    origin_id   = "APIGatewayOrigin"
+    origin_path = "/api"
+    domain_name = "${aws_api_gateway_rest_api.api.id}.execute-api.${data.aws_region.current.name}.amazonaws.com"
+
+    custom_origin_config {
+      origin_protocol_policy = "https-only"
+      origin_read_timeout    = 60
+      https_port             = 443
+      http_port              = 80
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  origin {
+    domain_name = trimsuffix(trimprefix(aws_lambda_function_url.ai_proxy.function_url, "https://"), "/")
+    origin_id   = "AIProxyOrigin"
+
+    custom_origin_config {
+      origin_protocol_policy = "https-only"
+      origin_read_timeout    = 60
+      https_port             = 443
+      http_port              = 80
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id       = "APIGatewayOrigin"
+    viewer_protocol_policy = "redirect-to-https"
+
+    cache_policy_id          = local.cloudfront_CachingDisabled
+    origin_request_policy_id = local.cloudfront_AllViewerExceptHostHeader
+  }
+
+  dynamic "ordered_cache_behavior" {
+    for_each = toset([
+      "/v1/proxy", "/v1/proxy/*",
+      "/v1/eval", "/v1/eval/*",
+      "/v1/function/*",
+      "/function/*"
+    ])
+    content {
+      path_pattern           = ordered_cache_behavior.value
+      allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+      cached_methods         = ["GET", "HEAD", "OPTIONS"]
+      target_origin_id       = "AIProxyOrigin"
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id          = local.cloudfront_CachingDisabled
+      origin_request_policy_id = local.cloudfront_AllViewerExceptHostHeader
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = var.custom_certificate_arn != null ? false : true
+    acm_certificate_arn            = var.custom_certificate_arn
+
+    # These can only be set if cloudfront_default_certificate is false
+    minimum_protocol_version = var.custom_certificate_arn != null ? "TLSv1.2_2021" : null
+    ssl_support_method       = var.custom_certificate_arn != null ? "sni-only" : null
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}

--- a/modules/services/outputs.tf
+++ b/modules/services/outputs.tf
@@ -1,0 +1,39 @@
+output "api_url" {
+  description = "The primary endpoint for the dataplane API. This is the value that should be entered into the braintrust dashboard under API URL."
+  value       = aws_cloudfront_distribution.dataplane.domain_name
+}
+
+output "ai_proxy_url" {
+  description = "The URL of the AI proxy lambda function"
+  value       = aws_lambda_function_url.ai_proxy.function_url
+}
+
+output "api_handler_arn" {
+  description = "The ARN of the API handler lambda function"
+  value       = aws_lambda_function.api_handler.arn
+}
+
+output "ai_proxy_arn" {
+  description = "The ARN of the AI proxy lambda function"
+  value       = aws_lambda_function.ai_proxy.arn
+}
+
+output "api_gateway_rest_api_arn" {
+  description = "The ARN of the API gateway rest api"
+  value       = aws_api_gateway_rest_api.api.arn
+}
+
+output "code_bundle_bucket_arn" {
+  description = "The ARN of the code bundle bucket"
+  value       = aws_s3_bucket.code_bundle_bucket.arn
+}
+
+output "lambda_responses_bucket_arn" {
+  description = "The ARN of the lambda responses bucket"
+  value       = aws_s3_bucket.lambda_responses_bucket.arn
+}
+
+output "cloudfront_distribution_arn" {
+  description = "The ARN of the cloudfront distribution"
+  value       = aws_cloudfront_distribution.dataplane.arn
+}

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -143,3 +143,15 @@ variable "run_draft_migrations" {
   description = "Enable draft migrations for database schema updates"
   default     = false
 }
+
+variable "custom_domain" {
+  description = "Custom domain name for the CloudFront distribution"
+  type        = string
+  default     = null
+}
+
+variable "custom_certificate_arn" {
+  description = "ARN of the ACM certificate for the custom domain"
+  type        = string
+  default     = null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "redis_arn" {
   value       = module.redis.redis_arn
   description = "ARN of the Redis instance"
 }
+
+output "api_url" {
+  value       = module.services.api_url
+  description = "The primary endpoint for the dataplane API. This is the value that should be entered into the braintrust dashboard under API URL."
+}


### PR DESCRIPTION
Cloudfront is the final piece for a basic data plane stack. This deploys successfully end-to-end and appears to work as a data plane in a test project.

Changes from Cloudformation:
* I removed the option to use the shared Cloudflare AI Proxy. It'll always use the self-hosted proxy.
* I enabled support for http3
* I changed the Price Class to "100" which means that it is only deployed in North America and Europe. This reduces costs and likely reduces deployment times. We don't use cloudfront for caching, so there isn't a ton of benefit to having additional locations anyway.

Other changes:
* Added additional outputs to the module, including the api_url (aka Universal URL)
* Enabled metrics for all routes in the API Gateway
* Small fix to API gateway to properly handle redeployments