### PR TITLE
Add support for KMS keys

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,8 @@ module "database" {
 
   postgres_storage_iops       = var.postgres_storage_iops
   postgres_storage_throughput = var.postgres_storage_throughput
+
+  kms_key_arn = var.kms_key_arn
 }
 
 module "redis" {
@@ -106,4 +108,5 @@ module "services" {
     module.quarantine_vpc[0].private_subnet_3_id
   ] : []
 
+  kms_key_arn = var.kms_key_arn
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,14 @@
+module "kms" {
+  source = "./modules/kms"
+  count  = var.kms_key_arn == null ? 1 : 0
+
+  deployment_name = var.deployment_name
+}
+
+locals {
+  kms_key_arn = var.kms_key_arn != null ? var.kms_key_arn : module.kms[0].key_arn
+}
+
 module "main_vpc" {
   source = "./modules/vpc"
 
@@ -50,7 +61,7 @@ module "database" {
   postgres_storage_iops       = var.postgres_storage_iops
   postgres_storage_throughput = var.postgres_storage_throughput
 
-  kms_key_arn = var.kms_key_arn
+  kms_key_arn = local.kms_key_arn
 }
 
 module "redis" {
@@ -108,5 +119,5 @@ module "services" {
     module.quarantine_vpc[0].private_subnet_3_id
   ] : []
 
-  kms_key_arn = var.kms_key_arn
+  kms_key_arn = local.kms_key_arn
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -36,6 +36,8 @@ resource "aws_db_instance" "main" {
 
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
+
+  kms_key_id = var.kms_key_arn
 }
 
 resource "aws_db_parameter_group" "main" {
@@ -117,4 +119,5 @@ resource "aws_secretsmanager_secret_version" "database_secret" {
 resource "aws_secretsmanager_secret" "database_secret" {
   name_prefix = "${var.deployment_name}/DatabaseSecret-"
   description = "Username/password for the main Braintrust RDS database"
+  kms_key_id  = var.kms_key_arn
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -51,7 +51,7 @@ variable "database_security_group_ids" {
 }
 
 variable "kms_key_arn" {
-  description = "KMS key ARN to use for encrypting resources. If not provided, the default AWS managed key is used."
+  description = "KMS key ARN to use for encrypting resources. If not provided, the default AWS managed key is used. DO NOT change this after deployment. If you do, it will attempt to destroy your DB."
   type        = string
   default     = null
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -49,3 +49,9 @@ variable "database_security_group_ids" {
   description = "Security Group IDs for the RDS instance."
   type        = list(string)
 }
+
+variable "kms_key_arn" {
+  description = "KMS key ARN to use for encrypting resources. If not provided, the default AWS managed key is used."
+  type        = string
+  default     = null
+}

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/elasticache/versions.tf
+++ b/modules/elasticache/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -1,4 +1,4 @@
-resource "aws_kms_key" "main" {
+resource "aws_kms_key" "braintrust" {
   description             = "KMS key for encrypting resources in the Braintrust data plane"
   key_usage               = "ENCRYPT_DECRYPT"
   deletion_window_in_days = 7
@@ -25,9 +25,9 @@ resource "aws_kms_key" "main" {
   }
 }
 
-resource "aws_kms_alias" "main" {
+resource "aws_kms_alias" "braintrust" {
   name          = "alias/braintrust/${var.deployment_name}"
-  target_key_id = aws_kms_key.main.key_id
+  target_key_id = aws_kms_key.braintrust.key_id
 }
 
 data "aws_caller_identity" "current" {}

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -1,0 +1,33 @@
+resource "aws_kms_key" "main" {
+  description             = "KMS key for encrypting resources in the Braintrust data plane"
+  key_usage               = "ENCRYPT_DECRYPT"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.deployment_name}-main"
+    Environment = var.deployment_name
+  }
+}
+
+resource "aws_kms_alias" "main" {
+  name          = "alias/braintrust/${var.deployment_name}"
+  target_key_id = aws_kms_key.main.key_id
+}
+
+data "aws_caller_identity" "current" {}

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -1,0 +1,4 @@
+output "key_arn" {
+  description = "The ARN of the KMS key"
+  value       = aws_kms_key.main.arn
+}

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -1,4 +1,9 @@
 output "key_arn" {
   description = "The ARN of the KMS key"
-  value       = aws_kms_key.main.arn
+  value       = aws_kms_key.braintrust.arn
+}
+
+output "key_alias" {
+  description = "The alias of the KMS key"
+  value       = aws_kms_alias.braintrust.name
 }

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -1,0 +1,4 @@
+variable "deployment_name" {
+  description = "Name of the deployment, used for resource naming"
+  type        = string
+}

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -1,5 +1,8 @@
+locals {
+  ai_proxy_function_name = "${var.deployment_name}-AIProxy"
+}
 resource "aws_lambda_function" "ai_proxy" {
-  function_name = "${var.deployment_name}-AIProxy"
+  function_name = local.ai_proxy_function_name
   s3_bucket     = local.lambda_s3_bucket
   s3_key        = local.lambda_versions["AIProxy"]
   role          = aws_iam_role.api_handler_role.arn
@@ -8,6 +11,12 @@ resource "aws_lambda_function" "ai_proxy" {
   memory_size   = 1024
   timeout       = 900
   publish       = true
+  kms_key_arn   = var.kms_key_arn
+
+  logging_config {
+    log_format = "Text"
+    log_group  = "/braintrust/${var.deployment_name}/${local.ai_proxy_function_name}"
+  }
 
   ephemeral_storage {
     size = 1024

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -15,6 +15,7 @@ resource "aws_lambda_function" "api_handler" {
   timeout       = 600
   publish       = true
   architectures = ["arm64"]
+  kms_key_arn   = var.kms_key_arn
 
   logging_config {
     log_format = "Text"

--- a/modules/services/lambda-catchup-etl.tf
+++ b/modules/services/lambda-catchup-etl.tf
@@ -1,5 +1,9 @@
+locals {
+  catchup_etl_function_name = "${var.deployment_name}-CatchupETL"
+}
+
 resource "aws_lambda_function" "catchup_etl" {
-  function_name = "${var.deployment_name}-CatchupETL"
+  function_name = local.catchup_etl_function_name
   s3_bucket     = local.lambda_s3_bucket
   s3_key        = local.lambda_versions["CatchupETL"]
   role          = aws_iam_role.default_role.arn
@@ -8,6 +12,7 @@ resource "aws_lambda_function" "catchup_etl" {
   memory_size   = 1024
   timeout       = 900
   architectures = ["arm64"]
+  kms_key_arn   = var.kms_key_arn
 
   environment {
     variables = {
@@ -19,6 +24,11 @@ resource "aws_lambda_function" "catchup_etl" {
       BRAINSTORE_URL                 = local.brainstore_url
       BRAINSTORE_REALTIME_WAL_BUCKET = local.brainstore_s3_bucket
     }
+  }
+
+  logging_config {
+    log_format = "Text"
+    log_group  = "/braintrust/${var.deployment_name}/${local.catchup_etl_function_name}"
   }
 
   vpc_config {

--- a/modules/services/lambda-migrate-database.tf
+++ b/modules/services/lambda-migrate-database.tf
@@ -1,5 +1,9 @@
+locals {
+  migrate_database_function_name = "${var.deployment_name}-MigrateDatabaseFunction"
+}
+
 resource "aws_lambda_function" "migrate_database" {
-  function_name = "${var.deployment_name}-MigrateDatabaseFunction"
+  function_name = local.migrate_database_function_name
   s3_bucket     = local.lambda_s3_bucket
   s3_key        = local.lambda_versions["MigrateDatabaseFunction"]
   role          = aws_iam_role.default_role.arn
@@ -8,7 +12,12 @@ resource "aws_lambda_function" "migrate_database" {
   memory_size   = 1024
   timeout       = 900
   publish       = true
+  kms_key_arn   = var.kms_key_arn
 
+  logging_config {
+    log_format = "Text"
+    log_group  = "/braintrust/${var.deployment_name}/${local.migrate_database_function_name}"
+  }
   environment {
     variables = {
       BRAINTRUST_RUN_DRAFT_MIGRATIONS = var.run_draft_migrations

--- a/modules/services/lambda-quarantine-warmup.tf
+++ b/modules/services/lambda-quarantine-warmup.tf
@@ -1,7 +1,11 @@
+locals {
+  quarantine_warmup_function_name = "${var.deployment_name}-QuarantineWarmupFunction"
+}
+
 resource "aws_lambda_function" "quarantine_warmup" {
   count = var.use_quarantine_vpc ? 1 : 0
 
-  function_name = "${var.deployment_name}-QuarantineWarmupFunction"
+  function_name = local.quarantine_warmup_function_name
   s3_bucket     = local.lambda_s3_bucket
   s3_key        = local.lambda_versions["QuarantineWarmupFunction"]
   role          = aws_iam_role.api_handler_role.arn
@@ -9,6 +13,7 @@ resource "aws_lambda_function" "quarantine_warmup" {
   runtime       = "nodejs20.x"
   memory_size   = 1024
   timeout       = 900
+  kms_key_arn   = var.kms_key_arn
 
   environment {
     variables = {
@@ -27,6 +32,11 @@ resource "aws_lambda_function" "quarantine_warmup" {
       QUARANTINE_PUB_PRIVATE_VPC_DEFAULT_SECURITY_GROUP = var.use_quarantine_vpc ? var.quarantine_vpc_default_security_group_id : ""
       QUARANTINE_PUB_PRIVATE_VPC_ID                     = var.use_quarantine_vpc ? var.quarantine_vpc_id : ""
     }
+  }
+
+  logging_config {
+    log_format = "Text"
+    log_group  = "/braintrust/${var.deployment_name}/${local.quarantine_warmup_function_name}"
   }
 
   vpc_config {

--- a/modules/services/s3.tf
+++ b/modules/services/s3.tf
@@ -12,6 +12,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "code_bundle_bucke
       sse_algorithm     = var.kms_key_arn != null ? "aws:kms" : "AES256"
       kms_master_key_id = var.kms_key_arn
     }
+    bucket_key_enabled = var.kms_key_arn != null
   }
 }
 
@@ -29,5 +30,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "lambda_responses_
       sse_algorithm     = var.kms_key_arn != null ? "aws:kms" : "AES256"
       kms_master_key_id = var.kms_key_arn
     }
+    bucket_key_enabled = var.kms_key_arn != null
   }
 }

--- a/modules/services/s3.tf
+++ b/modules/services/s3.tf
@@ -9,7 +9,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "code_bundle_bucke
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = var.kms_key_arn != null ? "aws:kms" : "AES256"
+      kms_master_key_id = var.kms_key_arn
     }
   }
 }
@@ -25,7 +26,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "lambda_responses_
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = var.kms_key_arn != null ? "aws:kms" : "AES256"
+      kms_master_key_id = var.kms_key_arn
     }
   }
 }

--- a/modules/services/secrets.tf
+++ b/modules/services/secrets.tf
@@ -1,6 +1,7 @@
 resource "aws_secretsmanager_secret" "function_tools_secret" {
   name_prefix = "${var.deployment_name}/FunctionToolsSecret-"
   description = "Function environment variables encryption key"
+  kms_key_id  = var.kms_key_arn
 }
 
 data "aws_secretsmanager_random_password" "function_tools_secret" {

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -157,7 +157,7 @@ variable "custom_certificate_arn" {
 }
 
 variable "kms_key_arn" {
-  description = "KMS key ARN to use for encrypting resources. If not provided, the default AWS managed key is used."
+  description = "KMS key ARN to use for encrypting resources. If not provided, the default AWS managed key is used. DO NOT change this after deployment. If you do, prior S3 objects will no longer be readable."
   type        = string
   default     = null
 }

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -155,3 +155,9 @@ variable "custom_certificate_arn" {
   type        = string
   default     = null
 }
+
+variable "kms_key_arn" {
+  description = "KMS key ARN to use for encrypting resources. If not provided, the default AWS managed key is used."
+  type        = string
+  default     = null
+}

--- a/modules/services/versions.tf
+++ b/modules/services/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "deployment_name" {
   }
 }
 
+variable "kms_key_arn" {
+  description = "KMS key ARN to use for encrypting resources. If not provided, the default AWS managed key is used."
+  type        = string
+  default     = null
+}
+
 ## NETWORKING
 variable "vpc_cidr" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "deployment_name" {
 }
 
 variable "kms_key_arn" {
-  description = "KMS key ARN to use for encrypting resources. If not provided, the default AWS managed key is used."
+  description = "Existing KMS key ARN to use for encrypting resources. If not provided, a new key will be created."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "deployment_name" {
 }
 
 variable "kms_key_arn" {
-  description = "Existing KMS key ARN to use for encrypting resources. If not provided, a new key will be created."
+  description = "Existing KMS key ARN to use for encrypting resources. If not provided, a new key will be created. DO NOT change this after deployment. If you do, it will attempt to destroy your DB and prior S3 objects will no longer be readable."
   type        = string
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,7 @@
 terraform {
-  required_version = ">= 1.0.0"
+  # v1.9 is needed for variable validation features
+  # v1.2 is needed for precondition checks
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Users can provide their own KMS key or let the module generate one for you. All submodules will now use the KMS key to encrypt.

The generated KMS key uses the default policy which allows the entire account to use it and delegates permissions to IAM.

Other changes:
* Require terraform 1.9 or higher
* Configure lambda log_groups to use the new naming format