### PR TITLE
Add VPC peering modules

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -5,6 +5,6 @@ plugin "terraform" {
 
 plugin "aws" {
     enabled = true
-    version = "0.36.0"
+    version = "0.37.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/examples/braintrust-data-plane/README.md
+++ b/examples/braintrust-data-plane/README.md
@@ -9,7 +9,9 @@ After applying this configuration, you will have a Braintrust data plane deploye
 If you are testing, it is HIGHLY recommended that you create a new Braintrust Organization for testing purposes. If you change your live Organization's API URL, you might break users who are currently using it.
 
 To configure your Organization to use your new data plane, click your user icon on the top right > Settings > API URL.
-![Setting the API URL in Braintrust](../../assets/Braintrust-API-URL.png)
+
+![Setting the API URL in Braintrust](/assets/Braintrust-API-URL.png)
 
 Paste the API URL into the text field and click Save. Click to copy the test ping command and run it in your terminal to verify that your data plane is working.
-![Verifying the API URL in Braintrust](../../assets/Braintrust-API-URL-2.png)
+
+![Verifying the API URL in Braintrust](/assets/Braintrust-API-URL-2.png)

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,10 @@ pre-commit = "latest"
 terraform = "1.10"
 
 [tasks]
+lint = ["terraform fmt -recursive", "tflint --recursive"]
 setup = ["pre-commit install", "tflint --init"]
-lint = ["terraform fmt", "tflint", "tflint --chdir modules --recursive"]
+validate = [
+    "terraform init && terraform validate",
+    "cd examples/braintrust-data-plane && terraform init && terraform validate",
+]
 precommit = ["pre-commit run --all-files"]

--- a/modules/vpc-peering-accepter/README.md
+++ b/modules/vpc-peering-accepter/README.md
@@ -1,0 +1,1 @@
+See the [vpc-peering-requester](../vpc-peering-requester/README.md) module for more information.

--- a/modules/vpc-peering-accepter/main.tf
+++ b/modules/vpc-peering-accepter/main.tf
@@ -1,0 +1,18 @@
+
+# Accept a VPC peering request from another VPC.
+resource "aws_vpc_peering_connection_accepter" "accepter" {
+  vpc_peering_connection_id = var.vpc_peering_connection_id
+  auto_accept               = true
+
+  tags = {
+    Name = "braintrust-peer-accepter"
+  }
+}
+
+# Add a route to the source route tables to allow communication with the destination VPC
+resource "aws_route" "requester_to_accepter" {
+  for_each                  = toset(var.source_route_table_ids)
+  route_table_id            = each.value
+  destination_cidr_block    = var.destination_cidr
+  vpc_peering_connection_id = var.vpc_peering_connection_id
+}

--- a/modules/vpc-peering-accepter/variables.tf
+++ b/modules/vpc-peering-accepter/variables.tf
@@ -1,0 +1,14 @@
+variable "destination_cidr" {
+  type        = string
+  description = "The CIDR block of the destination VPC you will be peered with. This can not overlap with your own VPC CIDR block."
+}
+
+variable "source_route_table_ids" {
+  type        = list(string)
+  description = "The IDs of the route tables in your VPC that you want to be able to communicate with the destination VPC"
+}
+
+variable "vpc_peering_connection_id" {
+  type        = string
+  description = "The ID of the VPC peering connection to accept. You need to get this from the requester."
+}

--- a/modules/vpc-peering-requester/README.md
+++ b/modules/vpc-peering-requester/README.md
@@ -1,0 +1,74 @@
+# VPC Peering Requester Module
+
+This Terraform module creates a VPC peering connection request from your Braintrust VPC (source) to another VPC (destination). This module handles the requester side of the VPC peering connection, including setting up the necessary routes in your VPC's route tables.
+
+A common use case is to peer your Braintrust VPC with your production VPC in a different AWS account. After peering is set up you will still need to add security group rules to allow traffic between the two VPCs.
+
+WARNING: This module requires coordination with the destination VPC owner to complete the peering connection. It will require multiple terraform applies and sharing of variables.
+
+Steps:
+1. Copy the module definition into a new file called `peering.tf` along side your existing terraform code for the Braintrust data plane.
+  a. Ask the destination VPC owner for the `destination_account_id`, `destination_vpc_id`, `destination_cidr`, and `destination_region`.
+2. Set `initiate_request_only` to `true` and run `terraform apply`.
+3. Note the `vpc_peering_connection_id` from the outputs and share it with the destination VPC owner.
+4. Wait for the destination VPC owner to accept the peering request. They should apply the `vpc-peering-accepter` module in their account.
+4. Set `initiate_request_only` to `false` and run `terraform apply` again. Your VPCs are now peered.
+5. Set up any security group rules needed to allow traffic between the two VPCs. This module does not handle security group rules.
+
+
+## Example Usage
+
+```hcl
+module "vpc_peering_requester" {
+  source = "./modules/vpc-peering-requester"
+
+  # Set this to true on your first apply. Set it to false after the peering request has been accepted.
+  initiate_request_only = true
+
+  source_vpc_id           = module.braintrust-data-plane.main_vpc_id
+  source_route_table_ids  = [
+    module.braintrust-data-plane.main_vpc_public_route_table_id,
+    module.braintrust-data-plane.main_vpc_private_route_table_id
+  ]
+
+  # Get these details from the destination VPC owner
+  destination_account_id  = ""
+  destination_vpc_id      = ""
+  destination_cidr        = ""
+  destination_region      = ""
+}
+```
+
+## Prerequisites
+
+- You must have access to both AWS accounts (source and destination) or at least be in in communication with the destination VPC owner.
+- The CIDR blocks of the source and destination VPCs must not overlap
+- The necessary IAM permissions to create VPC peering connections and modify route tables
+
+## Input Variables
+
+| Name | Description | Type | Required |
+|------|-------------|------|----------|
+| `source_vpc_id` | The ID of your VPC | `string` | Yes |
+| `source_route_table_ids` | The IDs of the route tables in your VPC that you want to be able to communicate with the destination VPC | `list(string)` | Yes |
+| `destination_account_id` | The account ID of the destination VPC you will be requesting to peer with | `string` | Yes |
+| `destination_vpc_id` | The ID of the destination VPC you will be requesting to peer with | `string` | Yes |
+| `destination_cidr` | The CIDR block of the destination VPC you will be requesting to peer with | `string` | Yes |
+| `destination_region` | The region of the destination VPC you will be requesting to peer with | `string` | Yes |
+| `initiate_request_only` | When set to true, only creates the peering request without setting up routes. Set to false after the peering request is accepted to create routes. | `bool` | Yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `vpc_peering_connection_id` | The ID of the VPC Peering Connection. Share this with the destination VPC owner to peer with them. |
+
+## Important Notes
+
+1. The `initiate_request_only` variable is crucial for the two-step setup process:
+   - First apply: Set to `true` to only create the peering request
+   - Second apply: Set to `false` after the request is accepted to create the routes
+2. This module only creates the peering request. The owner of the destination VPC must accept the peering request for the connection to become active.
+3. DNS resolution between VPCs is enabled by default in both the requester and accepter configurations.
+4. The module will automatically create routes in the specified source route tables to direct traffic to the destination VPC.
+5. Make sure to configure the corresponding routes in the destination VPC's route tables (this is handled by the `vpc-peering-accepter` module).

--- a/modules/vpc-peering-requester/main.tf
+++ b/modules/vpc-peering-requester/main.tf
@@ -1,0 +1,33 @@
+
+# Create a VPC peering request to a destination VPC. The Destination account owner needs to accept the request.
+resource "aws_vpc_peering_connection" "requester" {
+  peer_owner_id = var.destination_account_id
+  peer_vpc_id   = var.destination_vpc_id
+  peer_region   = var.destination_region
+  vpc_id        = var.source_vpc_id
+  auto_accept   = false
+
+  tags = {
+    Name = "braintrust-peer-requester"
+  }
+}
+
+resource "aws_vpc_peering_connection_options" "accept-dns" {
+  count                     = var.initiate_request_only ? 0 : 1
+  vpc_peering_connection_id = aws_vpc_peering_connection.requester.id
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+# Add a route to the source route tables to allow communication with the destination VPC
+resource "aws_route" "requester_to_accepter" {
+  count                     = var.initiate_request_only ? 0 : length(var.source_route_table_ids)
+  route_table_id            = var.source_route_table_ids[count.index]
+  destination_cidr_block    = var.destination_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.requester.id
+}

--- a/modules/vpc-peering-requester/outputs.tf
+++ b/modules/vpc-peering-requester/outputs.tf
@@ -1,0 +1,4 @@
+output "vpc_peering_connection_id" {
+  description = "The ID of the VPC Peering Connection. Share this with the destination VPC owner to peer with them."
+  value       = aws_vpc_peering_connection.requester.id
+}

--- a/modules/vpc-peering-requester/variables.tf
+++ b/modules/vpc-peering-requester/variables.tf
@@ -1,0 +1,35 @@
+variable "destination_account_id" {
+  type        = string
+  description = "The account ID of the destination VPC you will be requesting to peer with"
+}
+
+variable "destination_vpc_id" {
+  type        = string
+  description = "The ID of the destination VPC you will be requesting to peer with"
+}
+
+variable "destination_cidr" {
+  type        = string
+  description = "The CIDR block of the destination VPC you will be requesting to peer with. This can not overlap with your own VPC CIDR block."
+}
+
+variable "destination_region" {
+  type        = string
+  description = "The region of the destination VPC you will be requesting to peer with"
+}
+
+variable "source_vpc_id" {
+  type        = string
+  description = "The ID of your VPC"
+}
+
+variable "source_route_table_ids" {
+  type        = list(string)
+  description = "The IDs of the route tables in your VPC that you want to be able to communicate with the destination VPC"
+}
+
+variable "initiate_request_only" {
+  type        = bool
+  description = "Just initiate the request for the peer to accept it. Set this the first time you run, and then set it to false after the peer has accepted the request."
+  default     = true
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,8 +1,8 @@
 data "aws_region" "current" {}
 
 resource "aws_vpc" "vpc" {
-  cidr_block = var.vpc_cidr
-
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
   tags = {
     Name = "${var.deployment_name}-${var.vpc_name}"
   }

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -3,6 +3,11 @@ output "vpc_id" {
   value       = aws_vpc.vpc.id
 }
 
+output "vpc_cidr" {
+  description = "CIDR block of the VPC"
+  value       = aws_vpc.vpc.cidr_block
+}
+
 output "public_subnet_1_id" {
   description = "ID of the public subnet"
   value       = aws_subnet.public_subnet_1.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,16 @@ output "main_vpc_private_subnet_3_id" {
   description = "ID of the third private subnet in the main VPC"
 }
 
+output "main_vpc_public_route_table_id" {
+  value       = module.main_vpc.public_route_table_id
+  description = "ID of the public route table in the main VPC"
+}
+
+output "main_vpc_private_route_table_id" {
+  value       = module.main_vpc.private_route_table_id
+  description = "ID of the private route table in the main VPC"
+}
+
 output "postgres_database_arn" {
   value       = module.database.postgres_database_arn
   description = "ARN of the main Braintrust Postgres database"

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "quarantine_vpc_id" {
   description = "ID of the quarantine VPC that user functions run inside of."
 }
 
+output "main_vpc_cidr" {
+  value       = module.main_vpc.vpc_cidr
+  description = "CIDR block of the main VPC"
+}
+
 output "main_vpc_public_subnet_1_id" {
   value       = module.main_vpc.public_subnet_1_id
   description = "ID of the public subnet in the main VPC"

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,14 @@ variable "braintrust_org_name" {
 variable "deployment_name" {
   type        = string
   default     = "braintrust"
-  description = "Name of this Braintrust deployment. Will be included in tags and prefixes in resources names. Lowercase letters and hyphens only."
+  description = "Name of this Braintrust deployment. Will be included in tags and prefixes in resources names. Lowercase letter, numbers, and hyphens only. If you want multiple deployments in your same AWS account, use a unique name for each deployment."
   validation {
-    condition     = can(regex("^[a-z-]+$", var.deployment_name))
-    error_message = "The deployment_name must contain only lowercase letters and hyphens in order to be compatible with AWS resource naming restrictions."
+    condition     = can(regex("^[a-z0-9-]+$", var.deployment_name))
+    error_message = "The deployment_name must contain only lowercase letters, numbers and hyphens in order to be compatible with AWS resource naming restrictions."
+  }
+  validation {
+    condition     = length(var.deployment_name) <= 18
+    error_message = "The deployment_name must be 18 characters or less."
   }
 }
 


### PR DESCRIPTION
Add two modules to assist with setting up VPC peering. Unfortunately setting up peering in terraform is truly awful and requires a three step apply and coordinating steps with the destination VPC owner.

The Braintrust Data Plane should use the vpc-peering-requester modules to initiate a peering request. The destination VPC should use the vpc-peering-accepter module to accept it. Both modules will set up proper routes to allow bi-directional communication. The README has the details.

These modules do not try to modify security group rules. That should be handled individually depending on the use-case.

Other Changes:
* Stop using launch templates for clickhouse. Unfortunately terraform has a known long-standing bug and will always show drift of the user_data script
* Fix to the deployment_name to allow for numbers and to restrict the length