### PR TITLE
Peering DNS fixes

### DIFF
--- a/modules/clickhouse/main.tf
+++ b/modules/clickhouse/main.tf
@@ -18,6 +18,7 @@ data "aws_subnet" "clickhouse_subnet" {
   id = var.clickhouse_subnet_id
 }
 
+# nosemgrep
 resource "aws_instance" "clickhouse" {
   count                = var.clickhouse_instance_count
   ami                  = data.aws_ami.amazon_linux_2.id

--- a/modules/vpc-peering-accepter/main.tf
+++ b/modules/vpc-peering-accepter/main.tf
@@ -9,6 +9,14 @@ resource "aws_vpc_peering_connection_accepter" "accepter" {
   }
 }
 
+resource "aws_vpc_peering_connection_options" "accept-dns" {
+  vpc_peering_connection_id = var.vpc_peering_connection_id
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
 # Add a route to the source route tables to allow communication with the destination VPC
 resource "aws_route" "requester_to_accepter" {
   for_each                  = toset(var.source_route_table_ids)

--- a/modules/vpc-peering-requester/main.tf
+++ b/modules/vpc-peering-requester/main.tf
@@ -16,9 +16,6 @@ resource "aws_vpc_peering_connection_options" "accept-dns" {
   count                     = var.initiate_request_only ? 0 : 1
   vpc_peering_connection_id = aws_vpc_peering_connection.requester.id
 
-  accepter {
-    allow_remote_vpc_dns_resolution = true
-  }
   requester {
     allow_remote_vpc_dns_resolution = true
   }


### PR DESCRIPTION
Accepter and Requester DNS options need to be split up when doing cross account peering.