### PR TITLE
Allow for providing additional KMS key policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,8 @@ module "kms" {
   source = "./modules/kms"
   count  = var.kms_key_arn == null ? 1 : 0
 
-  deployment_name = var.deployment_name
+  deployment_name         = var.deployment_name
+  additional_key_policies = var.additional_kms_key_policies
 }
 
 locals {

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -6,17 +6,20 @@ resource "aws_kms_key" "braintrust" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "Enable IAM User Permissions"
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+    Statement = concat(
+      [
+        {
+          Sid    = "Enable IAM User Permissions"
+          Effect = "Allow"
+          Principal = {
+            AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          }
+          Action   = "kms:*"
+          Resource = "*"
         }
-        Action   = "kms:*"
-        Resource = "*"
-      }
-    ]
+      ],
+      var.additional_key_policies
+    )
   })
 
   tags = {

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -2,3 +2,8 @@ variable "deployment_name" {
   description = "Name of the deployment, used for resource naming"
   type        = string
 }
+variable "additional_key_policies" {
+  description = "Additional IAM policy statements to append to the KMS key policy"
+  type        = list(any)
+  default     = []
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "main_vpc_cidr" {
   description = "CIDR block of the main VPC"
 }
 
+output "main_vpc_default_security_group_id" {
+  value       = module.main_vpc.default_security_group_id
+  description = "ID of the default security group in the main VPC"
+}
+
 output "main_vpc_public_subnet_1_id" {
   value       = module.main_vpc.public_subnet_1_id
   description = "ID of the public subnet in the main VPC"

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,16 @@ variable "kms_key_arn" {
   default     = null
 }
 
+variable "additional_kms_key_policies" {
+  description = "Additional IAM policy statements to append to the generated KMS key."
+  type        = list(any)
+  default     = []
+  validation {
+    condition     = var.kms_key_arn == null
+    error_message = "additional_kms_key_policies can only be used if kms_key_arn is not provided."
+  }
+}
+
 ## NETWORKING
 variable "vpc_cidr" {
   type        = string


### PR DESCRIPTION
This is so it is possible to grant other systems to read/write the S3 bucket or other resources. 