### PR TITLE
Clickhouse password fix and variable validation fix

### DIFF
--- a/modules/clickhouse/user_data.sh
+++ b/modules/clickhouse/user_data.sh
@@ -33,11 +33,8 @@ yum install -y yum-utils jq
 yum-config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
 yum install -y clickhouse-server clickhouse-client
 
-# Extract password from secret
-PASSWORD=$(echo "$CLICKHOUSE_PASSWORD" | jq .password --raw-output | tr -d '\n')
-
 # Escape password for sed
-ESCAPED_PASSWORD=$(printf '%s\n' "$PASSWORD" | sed -e 's/[]\/$*.^[]/\\&/g')
+ESCAPED_PASSWORD=$(printf '%s\n' "$CLICKHOUSE_PASSWORD" | sed -e 's/[]\/$*.^[]/\\&/g')
 
 # Configure Clickhouse user password
 sed -i "s|<password></password>|<password>$ESCAPED_PASSWORD</password>|" /etc/clickhouse-server/users.xml

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "additional_kms_key_policies" {
   type        = list(any)
   default     = []
   validation {
-    condition     = var.kms_key_arn == null
+    condition     = length(var.additional_kms_key_policies) == 0 || var.kms_key_arn == null
     error_message = "additional_kms_key_policies can only be used if kms_key_arn is not provided."
   }
 }


### PR DESCRIPTION
When we moved to terraform we no longer stored the clickhouse password in secrets manager as a json. So this jq line isn't necessary and wasn't working which caused it to set no password.

Also the linter (and myself) failed to catch my bad validation logic on `additional_kms_key_policies`. Fixed now.