### PR TITLE
Pass the `id` of the clickhouse secret

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ module "services" {
   redis_port        = module.redis.redis_port
 
   clickhouse_host      = local.clickhouse_address
-  clickhouse_secret_id = try(module.clickhouse[0].clickhouse_secret_id, null)
+  clickhouse_secret_id = var.enable_clickhouse ? module.clickhouse[0].clickhouse_secret_id : null
 
   # Service configuration
   braintrust_org_name                 = var.braintrust_org_name

--- a/modules/clickhouse/outputs.tf
+++ b/modules/clickhouse/outputs.tf
@@ -14,10 +14,11 @@ output "clickhouse_s3_bucket_name" {
   value = try(aws_s3_bucket.clickhouse_s3_bucket[0].id, var.external_clickhouse_s3_bucket_name)
 }
 
-output "clickhouse_secret_version_id" {
-  # This is unfortunately needed because the AWSCURRENT version stage appears to be eventually consistent.
-  # If you try get the secret right after creating it, you will get an error saying AWSCURRENT doesn't exist.
-  # So instead you must point directly at the version_id
+output "clickhouse_secret_id" {
+  # This is a pipe delimited combination of secret ID and version ID
+  # This is unfortunately needed because the AWSCURRENT version alias appears to be eventually consistent.
+  # If you try get the secret by ID right after creating it, you will get an error saying AWSCURRENT doesn't exist.
+  # So instead you must point directly at the secret id and version id
   description = "The ID of the secret version"
-  value       = aws_secretsmanager_secret_version.clickhouse_secret.version_id
+  value       = aws_secretsmanager_secret_version.clickhouse_secret.id
 }


### PR DESCRIPTION
The version_id alone wasn't enough. This wasn't noticed because the `try()` function swallowed the error that would have said it was pointing at the wrong value.