### PR TITLE
Brainstore fixes

### DIFF
--- a/modules/brainstore/iam.tf
+++ b/modules/brainstore/iam.tf
@@ -84,6 +84,30 @@ resource "aws_iam_role_policy" "brainstore_cloudwatch_logs_access" {
   })
 }
 
+resource "aws_iam_role_policy" "brainstore_kms_policy" {
+  count = var.kms_key_arn != null ? 1 : 0
+
+  name = "${var.deployment_name}-brainstore-kms-policy"
+  role = aws_iam_role.brainstore_ec2_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = var.kms_key_arn
+      }
+    ]
+  })
+}
+
 resource "aws_iam_instance_profile" "brainstore" {
   name = "${var.deployment_name}-brainstore-instance-profile"
   role = aws_iam_role.brainstore_ec2_role.name

--- a/modules/brainstore/main.tf
+++ b/modules/brainstore/main.tf
@@ -1,13 +1,13 @@
-
 locals {
   brainstore_release_version = jsondecode(file("${path.module}/VERSIONS.json"))["brainstore"]
 }
 
 resource "aws_launch_template" "brainstore" {
-  name          = "${var.deployment_name}-brainstore"
-  image_id      = data.aws_ami.ubuntu_24_04.id
-  instance_type = var.instance_type
-  key_name      = var.instance_key_pair_name
+  name                   = "${var.deployment_name}-brainstore"
+  image_id               = data.aws_ami.ubuntu_24_04.id
+  instance_type          = var.instance_type
+  key_name               = var.instance_key_pair_name
+  update_default_version = true
 
   iam_instance_profile {
     arn = aws_iam_instance_profile.brainstore.arn
@@ -122,10 +122,10 @@ resource "aws_autoscaling_group" "brainstore" {
   # If too low, the ASG may terminate the instance before it has a chance to boot.
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore.arn]
-
+  wait_for_elb_capacity     = var.instance_count
   launch_template {
     id      = aws_launch_template.brainstore.id
-    version = "$Latest"
+    version = aws_launch_template.brainstore.latest_version
   }
 
   lifecycle {
@@ -139,6 +139,7 @@ resource "aws_autoscaling_group" "brainstore" {
       min_healthy_percentage = 100
       max_healthy_percentage = 200
     }
+    triggers = ["tag"]
   }
 }
 

--- a/modules/brainstore/templates/user_data.sh.tpl
+++ b/modules/brainstore/templates/user_data.sh.tpl
@@ -36,8 +36,9 @@ EOF
 # Set AWS region for CLI commands
 export AWS_DEFAULT_REGION=${aws_region}
 
+sudo snap install aws-cli --classic
 apt-get update
-apt-get install -y docker.io jq awscli earlyoom dstat
+apt-get install -y docker.io jq earlyoom dstat
 systemctl start docker
 systemctl enable docker
 

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -5,13 +5,22 @@ variable "deployment_name" {
 
 variable "instance_type" {
   type        = string
-  description = "The instance type to use for the Brainstore.Must be a Graviton instance type. Preferably with 16GB of memory and a local SSD for cache data. The default value is for tiny deployments. Recommended for production deployments is c7gd.8xlarge."
+  description = "The instance type to use for the Brainstore. Must be a Graviton instance type. Preferably with 16GB of memory and a local SSD for cache data. The default value is for tiny deployments. Recommended for production deployments is c7gd.8xlarge."
   default     = "c7gd.xlarge"
+
+  validation {
+    condition     = can(regex("[a-z0-9]*g[a-z0-9]*\\.", var.instance_type))
+    error_message = "Must be a Graviton instance type."
+  }
 }
 
 variable "license_key" {
   type        = string
   description = "The license key for the Brainstore"
+  validation {
+    condition     = length(var.license_key) > 0
+    error_message = "The license key cannot be empty."
+  }
 }
 
 variable "instance_count" {

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -16,6 +16,55 @@ resource "aws_kms_key" "braintrust" {
           }
           Action   = "kms:*"
           Resource = "*"
+        },
+        {
+          Sid    = "Allow Auto Scaling service to use the key"
+          Effect = "Allow"
+          Principal = {
+            AWS = [
+              "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ]
+          }
+          Action = [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+            "kms:DescribeKey",
+          ],
+          Resource = "*"
+        },
+        {
+          Sid    = "Allow EC2 service to use the key"
+          Effect = "Allow"
+          Principal = {
+            Service = "ec2.amazonaws.com"
+          }
+          Action = [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+          ],
+          Resource = "*"
+        },
+        {
+          Sid    = "Allow attachment of persistent resources"
+          Effect = "Allow"
+          Principal = {
+            AWS = [
+              "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ]
+          }
+          Action = [
+            "kms:CreateGrant"
+          ],
+          Resource = "*",
+          Condition = {
+            Bool = {
+              "kms:GrantIsForAWSResource" : true
+            }
+          }
         }
       ],
       var.additional_key_policies

--- a/variables.tf
+++ b/variables.tf
@@ -238,7 +238,7 @@ variable "enable_brainstore" {
 variable "brainstore_instance_type" {
   type        = string
   description = "The instance type to use for the Brainstore. Must be a Graviton instance type. Preferably with 16GB of memory and a local SSD for cache data. The default value is for tiny deployments. Recommended for production deployments is c7gd.8xlarge."
-  default     = "c5.xlarge"
+  default     = "c7gd.xlarge"
 }
 
 variable "brainstore_instance_count" {


### PR DESCRIPTION
Various fixes.
* The aws cli isn't in apt anymore. Use snap
* Ensure the ASG updates instances on changes to the template
* Allow the ASG and EC2 roles to use the kms key
* Ensure a graviton instance is used
* Ensure a license key is supplied