### PR TITLE
Fix duplicate prefix for s3 buckets

### DIFF
--- a/modules/services/iam.tf
+++ b/modules/services/iam.tf
@@ -184,10 +184,10 @@ resource "aws_iam_policy" "api_handler_policy" {
         Action = "s3:*"
         Effect = "Allow"
         Resource = concat([
-          "arn:aws:s3:::${aws_s3_bucket.lambda_responses_bucket.arn}",
-          "arn:aws:s3:::${aws_s3_bucket.lambda_responses_bucket.arn}/*",
-          "arn:aws:s3:::${aws_s3_bucket.code_bundle_bucket.arn}",
-          "arn:aws:s3:::${aws_s3_bucket.code_bundle_bucket.arn}/*",
+          aws_s3_bucket.lambda_responses_bucket.arn,
+          "${aws_s3_bucket.lambda_responses_bucket.arn}/*",
+          aws_s3_bucket.code_bundle_bucket.arn,
+          "${aws_s3_bucket.code_bundle_bucket.arn}/*",
           ],
           var.brainstore_s3_bucket_name != null && var.brainstore_s3_bucket_name != "" ? [
             "arn:aws:s3:::${var.brainstore_s3_bucket_name}",


### PR DESCRIPTION
This resolved to `arn:aws:s3:::arn:aws:s3:::btsbx-lambda-responses-20250218214129013900000001` which incorrectly duplicates the prefix (`arn:aws:s3:::`) and caused the lambda to not have permissions to write to the buckets.